### PR TITLE
Don't clear mocks unnecessarily

### DIFF
--- a/mockSSRCommands.js
+++ b/mockSSRCommands.js
@@ -2,7 +2,7 @@ beforeEach(() => {
   cy.clearSSRMocks()
 })
 
-afterEach(() => {
+after(() => {
   cy.clearSSRMocks()
 })
 


### PR DESCRIPTION
Clearing mocks before each test and also after each test is redundant. With `beforeEach` and `afterEach` defined, we end up seeing this behavior:

```
clear mocks (beforeEach)
test1 runs
clear mocks (afterEach)
clear mocks (beforeEach)
test2 runs
clear mocks (afterEach)
clear mocks (beforeEach)
test3 runs
clear mocks (afterEach)
```

However, if we were to change mock clearing to `beforeEach` and `after` we'd see this behavior:

```
clear mocks (beforeEach)
test1 runs
clear mocks (beforeEach)
test2 runs
clear mocks (beforeEach)
test3 runs
clear mocks (after)
```
