### PR TITLE
Make cypressMockMiddleware a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,32 +1,36 @@
 const connect = require('connect')
 const nock = require('nock')
 
-const cypressMockMiddleware = connect();
-
-cypressMockMiddleware.use('/__cypress_server_mock', function cypressServerMock(req, res) {
-  const chunks = []
-
-  req.on("data", (chunk) => {
-    chunks.push(chunk)
+const cypressMockMiddleware = () => {
+  const middleware = connect();
+  
+  middleware.use('/__cypress_server_mock', function cypressServerMock(req, res) {
+    const chunks = []
+    
+    req.on("data", (chunk) => {
+      chunks.push(chunk)
+    });
+    
+    req.on("end", () => {
+      const reqBody = JSON.parse(Buffer.concat(chunks).toString());
+      
+      const { hostname, method, path, statusCode, body } = reqBody
+      lcMethod = method.toLowerCase()
+      nock(hostname)[lcMethod](path).reply(statusCode, body)
+    });
+    res.statusCode = 200;
+    res.end()
   });
+  
+  middleware.use('/__cypress_clear_mocks', function cypressClearServerMock(req, res) {
+    nock.restore()
+    nock.cleanAll()
+    nock.activate()
+    res.statusCode = 200;
+    res.end()
+  })
 
-  req.on("end", () => {
-    const reqBody = JSON.parse(Buffer.concat(chunks).toString());
-
-    const { hostname, method, path, statusCode, body } = reqBody
-    lcMethod = method.toLowerCase()
-    nock(hostname)[lcMethod](path).reply(statusCode, body)
-  });
-  res.statusCode = 200;
-  res.end()
-});
-
-cypressMockMiddleware.use('/__cypress_clear_mocks', function cypressClearServerMock(req, res) {
-  nock.restore()
-  nock.cleanAll()
-  nock.activate()
-  res.statusCode = 200;
-  res.end()
-})
-
+  return middleware;
+}
+  
 module.exports = { cypressMockMiddleware };

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ const { cypressMockMiddleware } = require('@cypress/mock-ssr')
 
 const server = express()
 
-server.use(cypressMockMiddleware)
+server.use(cypressMockMiddleware())
 ```
 
 ### Express
@@ -39,7 +39,7 @@ const { cypressMockMiddleware } = require('@cypress/mock-ssr')
 
 const server = express()
 
-server.use(cypressMockMiddleware)
+server.use(cypressMockMiddleware())
 
 server.get("*", (req, res) => {
   // ...
@@ -67,7 +67,7 @@ const { cypressMockMiddleware } = require('@cypress/mock-ssr')
 app.prepare().then(() => {
   const server = express()
 
-  server.use(cypressMockMiddleware);
+  server.use(cypressMockMiddleware());
 
   server.get("*", (req, res) => {
     return handle(req, res)

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ describe('Cypress Mock SSR Middleware', function () {
   let app;
   beforeEach(function () {
     app = connect();
-    app.use(cypressMockMiddleware);
+    app.use(cypressMockMiddleware());
   })
   it('should accept a mock', function (done) {
     request(app)


### PR DESCRIPTION
This will allow us to add init options in the future if necessary without causing breaking changes